### PR TITLE
Support "by ref" and "by val"

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -6,9 +6,10 @@ fn main() {
 
     let v = vec![91,82,73,64,5,09,18,2,73,6,45,90,18,27,364,50,91,82,7,364,5];
     let list : List<i32> = v.iter().map(|x| *x ).collect();
-    let bt : BinaryTree<i32> = list.iter().collect();
+    let bt : BinaryTree<i32> = list.iter().map(|x| *x).collect();
 
     println!("Merge Sort: {:?}", merge_sort(&v));
     println!("bTree Sort: {:?}", bt.iter().collect::<Vec<&i32>>());
-    println!("List      : {:?}", list.iter().collect::<Vec<i32>>() );
+    println!("List      : {:?}", list.into_iter().collect::<Vec<i32>>() );
+
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -6,9 +6,10 @@ fn main() {
 
     let v = vec![91,82,73,64,5,09,18,2,73,6,45,90,18,27,364,50,91,82,7,364,5];
     let list : List<i32> = v.iter().map(|x| *x ).collect();
-    let bt : BinaryTree<i32> = list.iter().collect();
+    let bt : BinaryTree<i32> = list.into_iter().collect();
+    let list : List<i32> = v.iter().map(|x| *x ).collect();
 
     println!("Merge Sort: {:?}", merge_sort(&v));
     println!("bTree Sort: {:?}", bt.iter().collect::<Vec<&i32>>());
-    println!("List      : {:?}", list.iter().collect::<Vec<i32>>() );
+    println!("List      : {:?}", list.into_iter().collect::<Vec<i32>>() );
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -6,10 +6,9 @@ fn main() {
 
     let v = vec![91,82,73,64,5,09,18,2,73,6,45,90,18,27,364,50,91,82,7,364,5];
     let list : List<i32> = v.iter().map(|x| *x ).collect();
-    let bt : BinaryTree<i32> = list.into_iter().collect();
-    let list : List<i32> = v.iter().map(|x| *x ).collect();
+    let bt : BinaryTree<i32> = list.iter().collect();
 
     println!("Merge Sort: {:?}", merge_sort(&v));
     println!("bTree Sort: {:?}", bt.iter().collect::<Vec<&i32>>());
-    println!("List      : {:?}", list.into_iter().collect::<Vec<i32>>() );
+    println!("List      : {:?}", list.iter().collect::<Vec<i32>>() );
 }

--- a/src/linkedlists.rs
+++ b/src/linkedlists.rs
@@ -46,19 +46,11 @@ impl<T> List<T>
             }
         }
     }
-    // pub fn iter(&self) -> ListIter<T> {
-    //     match self {
-    //         List::Empty => ListIter { cursor: List::Empty },
-    //         List::NotEmpty(val, next) => {
-    //             ListIter {
-    //                 cursor: List::NotEmpty(
-    //                     val,
-    //                     next,
-    //                 )
-    //             }
-    //         }
-    //     }
-    // }
+    pub fn iter(&self) -> ListIterByRef<T> {
+        ListIterByRef {
+            cursor: self
+        }
+    }
 }
 
 /// List provides a "non-consuming" iterator... against the norm
@@ -107,6 +99,20 @@ pub struct ListIterByRef<'a, T>
     cursor: &'a List<T>,
 }
 
+impl<'a, T> Iterator for ListIterByRef<'a, T>
+    where T: Copy + Clone + PartialEq {
+
+    type Item = T;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.cursor {
+            List::Empty => None,
+            List::NotEmpty(value, next) => {
+                self.cursor = next;
+                Some(*value)
+            }
+        }
+    }
+}
 
 /// A List Iterator
 /// Sets up a cursor that references current node
@@ -171,7 +177,19 @@ mod tests {
         assert_eq!(l.pop(), None);
     }
     #[test]
-    fn test_list_into_iter() {
+    fn test_iter() {
+        let mut l = List::new();
+        l.push(1);
+        l.push(2);
+
+        let mut iter = l.iter();
+
+        assert_eq!(iter.next(), Some(1));
+        assert_eq!(iter.next(), Some(2));
+        assert_eq!(iter.next(), None)
+    }
+    #[test]
+    fn test_into_iter() {
         let mut l = List::new();
         l.push(1);
         l.push(2);


### PR DESCRIPTION
Into_iter() now consumes the list
iter() iterates by reference