### PR TITLE
Shallow merge & superimposing of ordered references

### DIFF
--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -1,6 +1,13 @@
-### Virtual Slice - continuous access over array fragments
-A `VirtualSlice` is composed out of one or more array fragments, adjacent to memory or not, and enables transparently operating over the **attached** array fragments. The virtualslice operates in two mode. Adjacent and non-adjacent 
-#### Memory Non-Adjacent arrays
+## Virtual Slice - continuous access over array fragments
+A `VirtualSlice` is composed out of one or more array fragments, adjacent to memory or not, and enables transparently operating over the **attached** array fragments. The virtualslice operates in two mode. Adjacent and non-adjacent
+
+* Need to access multiple slices as a single continuous one
+* Need to handle efficiently cases where slices are adjacent in memory
+* Need to perform a merge of two or more ordered slices
+* Need to perform "shallow" merge, that is, access the slices in the right order, while I shall be able to mutate them later on if I want to
+
+## Memory layout
+#### Non-Adjacent arrays Mode
 ```
 Left Array       Right Array
 +---+---+---+    +---+---+---+     
@@ -13,7 +20,7 @@ Left Array       Right Array
 | &2 | &4 | &6 | &1 | &3 | &5 |  Array of mutable references : Virtual Slice
 +----+----+----+----+----+----+  i.e. &2 = pointer/reference to left array[0]
 ```
-#### Memory Adjacent arrays
+#### Adjacent arrays Mode
 ```
     Left Array   Right Array
 +----+----+----+----+----+----+
@@ -24,7 +31,7 @@ Left Array       Right Array
     c            j
 ```
 ## Examples
-### Memory Adjacent arrays
+### Merging two adjacent slices
 ```
 use csx3::utils::VirtualSlice;
 let v = &mut [1, 3, 5, 7, 9, 2, 4, 6, 8, 10];
@@ -37,7 +44,7 @@ assert_eq!(s1, &mut [1, 2, 3, 4, 5]);
 assert_eq!(s2, &mut [6, 7, 8, 9, 10]);
 ```
 
-### Adjacent mode
+### Access & swap contents out of two non-adjacent slices
 ```
 use csx3::utils::VirtualSlice;
 
@@ -56,4 +63,41 @@ v.swap(0, 5);
 
 assert_eq!(s1, &mut [9, 3, 5, 7, 9]);
 assert_eq!(s4, &mut [11, 4, 6, 8 , 10]);
+```
+### Shallow merge across non-adjacent slices
+```
+use csx3::utils::VirtualSlice;
+
+let (s1, s2) = (&mut [5,6,7], &mut[1,2,3,4]);
+let mut vs = VirtualSlice::new();
+
+vs.attach(s1);                  // attach to s1
+vs.merge_shallow(s2);           // attach to s2 and do shallow merge with s1
+ 
+vs.iter()                       // ordered access of attached slices
+    .enumerate()                // [&1, &2, &3, &4, &5, &6, &7]
+    .for_each(|(i,x)| 
+        assert_eq(*x,i+1) 
+     );
+
+assert_eq!(s1, &[1,2,3]);       // while s1 & s2 are unaffected
+assert_eq!(s2, &[4,5,6,7]);
+```
+### Superimpose merged order
+```
+use csx3::utils::VirtualSlice;
+
+let (s1, s2) = (&mut [5,6,7], &mut[1,2,3,4]);
+let mut vs = VirtualSlice::new();
+
+vs.attach(s1);                  // attach to s1
+vs.merge_shallow(s2);           // attach to s2 and do shallow merge with s1
+                                
+                                // vs == &[&1,&2,&3,&4,&5,&6,&7]
+                                // s1 == &[5,6,7]
+                                // s2 == &[1,2,3,4]
+vs.impose_shallow_merge();      // superimpose order mask
+
+assert_eq!(s1, &[1,2,3]);
+assert_eq!(s2, &[4,5,6,7]);
 ```

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -634,6 +634,10 @@ mod test {
             vec![&mut 1, &mut 2, &mut 3, &mut 4, &mut 5, &mut 6, &mut 7, &mut 8, &mut 9,&mut 10],
             vec![]
         ));
+        vs.iter()
+            .enumerate()
+            .for_each(|(i,x)| assert_eq!(*x,i+1) );
+
         assert_eq!( s1, &mut [1, 3, 5, 7, 9] );
         assert_eq!( s2, &mut [2, 4, 6, 8, 10] );
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,8 +1,7 @@
 use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
-use std::mem;
 use std::ops::{Index, IndexMut, Range};
-
+use std::mem;
 
 /// Constructing a VirtualSlice allowing us to operate over
 /// multiple non-adjacent slice segments as a "continuous slice"
@@ -125,20 +124,20 @@ impl<'a, T> VirtualSlice<'a, T> where T: Ord {
                 return false;
             }
 
-            // let (mut n, mut c, mut total, len) = (0usize, 0usize, 0usize, self.len());
-            // let mut tmp: T;
-            //
+            let (mut n, mut c, mut total, len) = (0usize, 0usize, 0usize, v.len());
+            let mut temp : Option<&mut T> = None;
+
             // while total < len {
             //     c += 1;
-            //     mem::swap(&mut tmp, &mut self[idx_rfl[c]]);
-            //     while true {
+            //     mem::replace(&mut temp, Some( v[idx_rfl[c]] ) );
+            //     while let Some(ref mut tmp) = temp  {
             //         n = idx_rfl[c];
-            //         mem::swap(&mut tmp, &mut self[n]);
+            //         mem::replace(tmp, v[n]);
             //         c = n;
             //         total += 1;
             //     }
             // }
-            // return true;
+            return true;
         }
         return false;
     }
@@ -575,13 +574,12 @@ mod test {
         let _z = &[0,0,0,0,0,0]; // wedge to break adjacency
         let s4 = &mut [8,9,15,16];
 
-        {
-            let mut vs = VirtualSlice::new();
-            vs.merge(s1);
-            vs.merge(s2);
-            vs.merge(s3);
-            vs.merge(s4);
-        }
+        let mut vs = VirtualSlice::new();
+        vs.merge(s1);
+        vs.merge(s2);
+        vs.merge(s3);
+        vs.merge(s4);
+
         assert_eq!(s1, &mut [1,2,3]);
         assert_eq!(s2, &mut [4,5,6,7]);
         assert_eq!(s3, &mut [8,9,10]);


### PR DESCRIPTION
+ merge() - attached slices and VirualSlice are now reordered
+ merge_swallow()  -  VirtualSlice is now ordered however attached slices are unaffected
+ superimpose_merge_shallow() - Superimposes VirtualSlice order on attached slices